### PR TITLE
workon: fix platform feature imports and add missing domain structure

### DIFF
--- a/apps/portals/shared/features/platform/index.ts
+++ b/apps/portals/shared/features/platform/index.ts
@@ -1,0 +1,5 @@
+// Platform feature exports
+export * from './platform.service';
+export * from './platform-api.service';
+export * from './platform-list-container.directive';
+export * from './platform.providers';

--- a/apps/portals/shared/features/platform/jest.config.ts
+++ b/apps/portals/shared/features/platform/jest.config.ts
@@ -1,0 +1,5 @@
+import { getJestProjects } from '@nx/jest';
+
+export default {
+  projects: getJestProjects()
+};

--- a/apps/portals/shared/features/platform/platform-api.service.ts
+++ b/apps/portals/shared/features/platform/platform-api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core";
 import { Observable, of } from "rxjs";
 import { Result } from "@standard";
-import { IPlatformsProvider, PlatformDto } from "../../../../../../../libs/features/listing/platform/application";
+import { IPlatformsProvider, PlatformDto } from "@domains/catalog/platform";
 
 @Injectable()
 export class PlatformApiService implements IPlatformsProvider {

--- a/apps/portals/shared/features/platform/platform-list-container.directive.ts
+++ b/apps/portals/shared/features/platform/platform-list-container.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, inject } from "@angular/core";
-import { PlatformService } from "../../../../../libs/features/listing/platform/application";
+import { PlatformService } from "@features/listing";
 import { asyncScheduler, delay, observeOn, tap } from "rxjs";
 
 @Directive({

--- a/apps/portals/shared/features/platform/platform.providers.ts
+++ b/apps/portals/shared/features/platform/platform.providers.ts
@@ -1,6 +1,7 @@
 import { ApplicationConfig } from "@angular/core";
-import { PLATFORMS_PROVIDER, PlatformService } from "../../../../../libs/features/listing/platform/application";
-import { PlatformApiService } from "./infrastructure/platform-api.service";
+import { PLATFORMS_PROVIDER } from "@domains/catalog/platform";
+import { PlatformService } from "@features/listing";
+import { PlatformApiService } from "./platform-api.service";
 
 export function provideListingPlatformFeature(): ApplicationConfig {
   return {

--- a/apps/portals/shared/features/platform/project.json
+++ b/apps/portals/shared/features/platform/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "platform",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "prefix": "plt",
+  "sourceRoot": "apps/portals/shared/features/platform",
+  "tags": ["type:platform", "scope:catalog"],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/apps/portals/shared/features/platform",
+        "main": "apps/portals/shared/features/platform/index.ts",
+        "tsConfig": "apps/portals/shared/features/platform/tsconfig.lib.json",
+        "assets": ["apps/portals/shared/features/platform/*.md"]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "apps/portals/shared/features/platform/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    }
+  }
+}

--- a/apps/portals/shared/features/platform/tsconfig.json
+++ b/apps/portals/shared/features/platform/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
+}

--- a/apps/portals/shared/features/platform/tsconfig.lib.json
+++ b/apps/portals/shared/features/platform/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/apps/portals/shared/features/platform/tsconfig.spec.json
+++ b/apps/portals/shared/features/platform/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.test.ts"
+  ]
+}

--- a/libs/domains/catalog/platform/application/index.ts
+++ b/libs/domains/catalog/platform/application/index.ts
@@ -1,0 +1,2 @@
+export * from './ports';
+export * from './models';

--- a/libs/domains/catalog/platform/application/models/index.ts
+++ b/libs/domains/catalog/platform/application/models/index.ts
@@ -1,0 +1,1 @@
+export * from './platform.dto';

--- a/libs/domains/catalog/platform/application/ports/index.ts
+++ b/libs/domains/catalog/platform/application/ports/index.ts
@@ -1,0 +1,1 @@
+export * from './platforms-provider.port';

--- a/libs/domains/catalog/platform/index.ts
+++ b/libs/domains/catalog/platform/index.ts
@@ -1,0 +1,1 @@
+export * from './application';

--- a/libs/features/listing/index.ts
+++ b/libs/features/listing/index.ts
@@ -1,0 +1,1 @@
+export * from './platform/application';

--- a/libs/features/listing/jest.config.ts
+++ b/libs/features/listing/jest.config.ts
@@ -1,0 +1,5 @@
+import { getJestProjects } from '@nx/jest';
+
+export default {
+  projects: getJestProjects()
+};

--- a/libs/features/listing/platform/application/index.ts
+++ b/libs/features/listing/platform/application/index.ts
@@ -1,0 +1,1 @@
+export * from './platform.service';

--- a/libs/features/listing/platform/application/platform.service.ts
+++ b/libs/features/listing/platform/application/platform.service.ts
@@ -11,4 +11,4 @@ export class PlatformService {
       map(r => r.value ?? []),
       shareReplay({ bufferSize: 1, refCount: false }))
     ;
-} 
+}

--- a/libs/features/listing/project.json
+++ b/libs/features/listing/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "features-listing",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "prefix": "lst",
+  "sourceRoot": "libs/features/listing",
+  "tags": ["type:listing", "scope:catalog"],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/features/listing",
+        "main": "libs/features/listing/index.ts",
+        "tsConfig": "libs/features/listing/tsconfig.lib.json",
+        "assets": ["libs/features/listing/*.md"]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/features/listing/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    }
+  }
+}

--- a/libs/features/listing/tsconfig.json
+++ b/libs/features/listing/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
+}

--- a/libs/features/listing/tsconfig.lib.json
+++ b/libs/features/listing/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/libs/features/listing/tsconfig.spec.json
+++ b/libs/features/listing/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -66,6 +66,7 @@
       "@portals/cross-cutting/environment": ["apps/portals/shared/cross-cutting/environment/src/index.ts"],
       "@domains/catalog/category": ["libs/domains/catalog/category/src/index.ts"],
       "@domains/catalog/entry": ["libs/domains/catalog/entry/application/index.ts"],
+      "@domains/catalog/platform": ["libs/domains/catalog/platform/index.ts"],
       "@domains/catalog/compatibility": ["libs/domains/catalog/compatibility/application/index.ts"],
       "@portals/shared/features/filtering": ["apps/portals/shared/features/filtering/src/index.ts"]
     }


### PR DESCRIPTION
- Add missing index files for platform domain layers
- Create features/listing library with proper Nx boilerplate
- Fix import paths to use proper aliases (@domains/catalog/platform, @features/listing)
- Add @domains/catalog/platform alias to root tsconfig
- Create proper Nx project structure for platform feature
- Fix TypeScript compilation issues