### PR TITLE
workon: fix pricing feature imports and add missing Nx boilerplate

### DIFF
--- a/apps/portals/shared/features/pricing/jest.config.ts
+++ b/apps/portals/shared/features/pricing/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: 'portals-shared-features-pricing',
+  preset: '../../../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }]
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../../../coverage/apps/portals/shared/features/pricing'
+};

--- a/apps/portals/shared/features/pricing/project.json
+++ b/apps/portals/shared/features/pricing/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "portals-shared-features-pricing",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "prefix": "prc",
+  "sourceRoot": "apps/portals/shared/features/pricing",
+  "tags": ["type:pricing", "scope:catalog"],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/apps/portals/shared/features/pricing",
+        "main": "apps/portals/shared/features/pricing/src/index.ts",
+        "tsConfig": "apps/portals/shared/features/pricing/tsconfig.lib.json",
+        "assets": ["apps/portals/shared/features/pricing/*.md"]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "apps/portals/shared/features/pricing/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    }
+  }
+}

--- a/apps/portals/shared/features/pricing/src/application/index.ts
+++ b/apps/portals/shared/features/pricing/src/application/index.ts
@@ -1,0 +1,2 @@
+export * from './monetization.service';
+export * from './ports/monetization-provider.port';

--- a/apps/portals/shared/features/pricing/src/application/ports/monetization-provider.port.ts
+++ b/apps/portals/shared/features/pricing/src/application/ports/monetization-provider.port.ts
@@ -1,0 +1,10 @@
+import { InjectionToken } from "@angular/core";
+import { Observable } from "rxjs";
+import { Result } from "@standard";
+import { MonetizationDto } from "@domains/catalog/pricing";
+
+export const MONETIZATION_PROVIDER = new InjectionToken<IMonetizationProvider>('MONETIZATION_PROVIDER_PORT');
+
+export interface IMonetizationProvider {
+  getMonetizations(): Observable<Result<MonetizationDto[], Error>>;
+}

--- a/apps/portals/shared/features/pricing/src/index.ts
+++ b/apps/portals/shared/features/pricing/src/index.ts
@@ -1,0 +1,4 @@
+export * from './application';
+export * from './infrastructure';
+export * from './presentation';
+export * from './monetization.providers';

--- a/apps/portals/shared/features/pricing/src/infrastructure/index.ts
+++ b/apps/portals/shared/features/pricing/src/infrastructure/index.ts
@@ -1,0 +1,1 @@
+export * from './monetization-api.service';

--- a/apps/portals/shared/features/pricing/src/infrastructure/monetization-api.service.ts
+++ b/apps/portals/shared/features/pricing/src/infrastructure/monetization-api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core";
 import { Observable, of } from "rxjs";
 import { Result } from "@standard";
-import { IMonetizationProvider, MonetizationDto } from "../../../../../libs/features/listing/monetization/application";
+import { IMonetizationProvider, MonetizationDto } from "@domains/catalog/pricing";
 
 @Injectable()
 export class MonetizationApiService implements IMonetizationProvider {

--- a/apps/portals/shared/features/pricing/src/monetization.providers.ts
+++ b/apps/portals/shared/features/pricing/src/monetization.providers.ts
@@ -1,6 +1,6 @@
 import { ApplicationConfig } from "@angular/core";
-import { MONETIZATION_PROVIDER, MonetizationService } from "../../../../../libs/features/listing/monetization/application";
-import { MonetizationApiService } from "./monetization-api.service";
+import { MONETIZATION_PROVIDER, MonetizationService } from "./application";
+import { MonetizationApiService } from "./infrastructure";
 
 export function provideListingMonetizationFeature(): ApplicationConfig {
   return {

--- a/apps/portals/shared/features/pricing/src/presentation/index.ts
+++ b/apps/portals/shared/features/pricing/src/presentation/index.ts
@@ -1,0 +1,1 @@
+export * from './monetization-list-container.directive';

--- a/apps/portals/shared/features/pricing/src/presentation/monetization-list-container.directive.ts
+++ b/apps/portals/shared/features/pricing/src/presentation/monetization-list-container.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, inject } from "@angular/core";
-import { MonetizationService } from "../../../../../libs/features/listing/monetization/application";
+import { MonetizationService } from "../application";
 
 @Directive({
   selector: '[monetizationListContainer]',

--- a/apps/portals/shared/features/pricing/tsconfig.json
+++ b/apps/portals/shared/features/pricing/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
+}

--- a/apps/portals/shared/features/pricing/tsconfig.lib.json
+++ b/apps/portals/shared/features/pricing/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/apps/portals/shared/features/pricing/tsconfig.spec.json
+++ b/apps/portals/shared/features/pricing/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}

--- a/libs/domains/catalog/pricing/application/index.ts
+++ b/libs/domains/catalog/pricing/application/index.ts
@@ -1,0 +1,2 @@
+export * from './ports';
+export * from './models';

--- a/libs/domains/catalog/pricing/application/models/index.ts
+++ b/libs/domains/catalog/pricing/application/models/index.ts
@@ -1,0 +1,1 @@
+export * from './monetization.dto';

--- a/libs/domains/catalog/pricing/application/ports/index.ts
+++ b/libs/domains/catalog/pricing/application/ports/index.ts
@@ -1,0 +1,1 @@
+export * from './monetization-provider.port';

--- a/libs/domains/catalog/pricing/index.ts
+++ b/libs/domains/catalog/pricing/index.ts
@@ -1,0 +1,1 @@
+export * from './application';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -67,9 +67,11 @@
       "@domains/catalog/category": ["libs/domains/catalog/category/src/index.ts"],
       "@domains/catalog/entry": ["libs/domains/catalog/entry/application/index.ts"],
       "@domains/catalog/platform": ["libs/domains/catalog/platform/index.ts"],
+      "@domains/catalog/pricing": ["libs/domains/catalog/pricing/index.ts"],
       "@domains/catalog/compatibility": ["libs/domains/catalog/compatibility/application/index.ts"],
       "@domains/customer/my-profile": ["libs/domains/customer/my-profile/application/index.ts"],
       "@domains/identity": ["libs/domains/identity/index.ts"],
+      "@portals/shared/features/pricing": ["apps/portals/shared/features/pricing/src/index.ts"],
       "@portals/shared/features/filtering": ["apps/portals/shared/features/filtering/src/index.ts"],
       "@portals/shared/features/metrics": ["apps/portals/shared/features/metrics/src/index.ts"]
     }


### PR DESCRIPTION
- Add missing Nx boilerplate files (project.json, tsconfig files, jest.config.ts) based on categories boilerplate
- Create proper layer structure with index files (application, infrastructure, presentation)
- Fix import paths to use proper aliases (@domains/catalog/pricing, @portals/shared/features/pricing)
- Add missing monetization provider port file
- Create comprehensive domain structure with proper exports
- Add @domains/catalog/pricing and @portals/shared/features/pricing aliases to root tsconfig
- Fix TypeScript compilation issues
- Follow architectural conventions from feature.definition.md