### PR TITLE
fix(dialogs): standardize tsconfig files and fix import paths

### DIFF
--- a/apps/portals/aggregator/application/src/components/dialogs/authentication-dialog/authentication-dialog.component.ts
+++ b/apps/portals/aggregator/application/src/components/dialogs/authentication-dialog/authentication-dialog.component.ts
@@ -1,8 +1,8 @@
 import { Component, inject, OnDestroy, OnInit } from "@angular/core";
 import { TuiLink } from "@taiga-ui/core";
-import { RoutedDialogButton } from "../../../libs/ui/directives/identity-routed-dialog-button.directive";
-import { LoginContainerComponent } from "../../../libs/features/identity/login/presentation/login-container";
-import { AuthenticationService } from "../../../libs/aspects/authentication/application";
+import { RoutedDialogButton } from "@ui/routable-dialog";
+import { LoginContainerComponent } from "@ui/login";
+import { IAuthenticationProvider } from "@domains/customer/my-profile";
 import { filter, Subscription } from "rxjs";
 import { ActivatedRoute, Router } from "@angular/router";
 
@@ -17,7 +17,7 @@ import { ActivatedRoute, Router } from "@angular/router";
   ]
 })
 export class AuthenticationDialogComponent implements OnInit, OnDestroy {
-  private readonly _service = inject(AuthenticationService);
+  private readonly _service = inject(IAuthenticationProvider);
   private readonly _router = inject(Router);
   private readonly _activatedRoute = inject(ActivatedRoute);
   private _s: Subscription | undefined;

--- a/apps/portals/aggregator/application/src/components/dialogs/lost-password-dialog/lost-password-dialog.component.ts
+++ b/apps/portals/aggregator/application/src/components/dialogs/lost-password-dialog/lost-password-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component } from "@angular/core";
 import { TuiLink } from "@taiga-ui/core";
-import { PasswordResetRequestContainer } from "../../../libs/features/identity/password-reset-request/presentation/password-reset-request-container/password-reset-request-container.component";
-import { RoutedDialogButton } from "../../../libs/ui/directives/identity-routed-dialog-button.directive";
+import { PasswordResetRequestContainer } from "@ui/password-reset";
+import { RoutedDialogButton } from "@ui/routable-dialog";
 
 @Component({
   templateUrl: "lost-password-dialog.component.html",

--- a/apps/portals/aggregator/application/src/components/dialogs/registration-dialog/registration-dialog.component.ts
+++ b/apps/portals/aggregator/application/src/components/dialogs/registration-dialog/registration-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component } from "@angular/core";
 import { TuiLink } from "@taiga-ui/core";
-import { RoutedDialogButton } from "../../../libs/ui/directives/identity-routed-dialog-button.directive";
-import { RegistrationContainerComponent } from "../../../libs/features/identity/registration/presentation/registration-container";
+import { RoutedDialogButton } from "@ui/routable-dialog";
+import { RegistrationContainerComponent } from "@ui/registration";
 
 @Component({
   templateUrl: "registration-dialog.component.html",

--- a/apps/portals/aggregator/application/src/components/pages/home/home.component.ts
+++ b/apps/portals/aggregator/application/src/components/pages/home/home.component.ts
@@ -1,8 +1,7 @@
 import { Component } from "@angular/core";
-import { ListingSearchService } from "../../../libs/features/listing/search/services/listing-search.service";
-import { StickyElementDirective } from "../../../libs/ui/directives/sticky-element/sticky-element.directive";
-import { MultiSearchComponent } from "../../../libs/ui/components/multi-search/multi-search.component";
-import { MULTISEARCH_RESULTS_PROVIER, MULTISEARCH_STATE_PROVIDER } from "../../../libs/ui/components/multi-search/multi-search.constants";
+import { ListingSearchService } from "@portals/shared/features/search";
+import { StickyElementDirective } from "@ui/misc";
+import { MultiSearchComponent, MULTISEARCH_RESULTS_PROVIER, MULTISEARCH_STATE_PROVIDER } from "@ui/multi-search";
 import { HomePageStateService } from "./home-page-state.service";
 
  

--- a/apps/portals/aggregator/application/tsconfig.app.json
+++ b/apps/portals/aggregator/application/tsconfig.app.json
@@ -4,6 +4,6 @@
     "outDir": "../../../../dist/out-tsc",
     "types": []
   },
-  "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
 }

--- a/libs/ui/filters/tsconfig.json
+++ b/libs/ui/filters/tsconfig.json
@@ -1,19 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022", "DOM"],
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "outDir": "../../../dist/out-tsc",
-    "rootDir": ".",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
 }

--- a/libs/ui/filters/tsconfig.lib.json
+++ b/libs/ui/filters/tsconfig.lib.json
@@ -4,6 +4,6 @@
     "outDir": "../../../dist/out-tsc",
     "types": []
   },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libs/ui/filters/tsconfig.spec.json
+++ b/libs/ui/filters/tsconfig.spec.json
@@ -2,7 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/form/tsconfig.spec.json
+++ b/libs/ui/form/tsconfig.spec.json
@@ -2,8 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"],
-  "exclude": ["jest.config.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/infinite-scroll/tsconfig.json
+++ b/libs/ui/infinite-scroll/tsconfig.json
@@ -1,19 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022", "DOM"],
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "outDir": "../../../dist/out-tsc",
-    "rootDir": ".",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
 }

--- a/libs/ui/infinite-scroll/tsconfig.lib.json
+++ b/libs/ui/infinite-scroll/tsconfig.lib.json
@@ -4,6 +4,6 @@
     "outDir": "../../../dist/out-tsc",
     "types": []
   },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libs/ui/infinite-scroll/tsconfig.spec.json
+++ b/libs/ui/infinite-scroll/tsconfig.spec.json
@@ -2,7 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/items-listing/tsconfig.json
+++ b/libs/ui/items-listing/tsconfig.json
@@ -1,19 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022", "DOM"],
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "outDir": "../../../dist/out-tsc",
-    "rootDir": ".",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
 }

--- a/libs/ui/items-listing/tsconfig.lib.json
+++ b/libs/ui/items-listing/tsconfig.lib.json
@@ -4,6 +4,6 @@
     "outDir": "../../../dist/out-tsc",
     "types": []
   },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libs/ui/items-listing/tsconfig.spec.json
+++ b/libs/ui/items-listing/tsconfig.spec.json
@@ -2,7 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/layout/tsconfig.json
+++ b/libs/ui/layout/tsconfig.json
@@ -1,19 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022", "DOM"],
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "outDir": "../../../dist/out-tsc",
-    "rootDir": ".",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
 }

--- a/libs/ui/layout/tsconfig.lib.json
+++ b/libs/ui/layout/tsconfig.lib.json
@@ -4,6 +4,6 @@
     "outDir": "../../../dist/out-tsc",
     "types": []
   },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libs/ui/layout/tsconfig.spec.json
+++ b/libs/ui/layout/tsconfig.spec.json
@@ -2,7 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/login/tsconfig.json
+++ b/libs/ui/login/tsconfig.json
@@ -1,19 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022", "DOM"],
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "outDir": "../../../dist/out-tsc",
-    "rootDir": ".",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
 }

--- a/libs/ui/login/tsconfig.lib.json
+++ b/libs/ui/login/tsconfig.lib.json
@@ -4,6 +4,6 @@
     "outDir": "../../../dist/out-tsc",
     "types": []
   },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libs/ui/login/tsconfig.spec.json
+++ b/libs/ui/login/tsconfig.spec.json
@@ -2,7 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/misc/tsconfig.lib.json
+++ b/libs/ui/misc/tsconfig.lib.json
@@ -4,6 +4,6 @@
     "outDir": "../../../dist/out-tsc",
     "types": []
   },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libs/ui/misc/tsconfig.spec.json
+++ b/libs/ui/misc/tsconfig.spec.json
@@ -2,7 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/multi-search/tsconfig.json
+++ b/libs/ui/multi-search/tsconfig.json
@@ -1,19 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022", "DOM"],
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "outDir": "../../../dist/out-tsc",
-    "rootDir": ".",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
 }

--- a/libs/ui/multi-search/tsconfig.lib.json
+++ b/libs/ui/multi-search/tsconfig.lib.json
@@ -4,6 +4,6 @@
     "outDir": "../../../dist/out-tsc",
     "types": []
   },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libs/ui/multi-search/tsconfig.spec.json
+++ b/libs/ui/multi-search/tsconfig.spec.json
@@ -2,7 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/my-profile/tsconfig.json
+++ b/libs/ui/my-profile/tsconfig.json
@@ -1,19 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022", "DOM"],
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "outDir": "../../../dist/out-tsc",
-    "rootDir": ".",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
 }

--- a/libs/ui/my-profile/tsconfig.lib.json
+++ b/libs/ui/my-profile/tsconfig.lib.json
@@ -4,6 +4,6 @@
     "outDir": "../../../dist/out-tsc",
     "types": []
   },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libs/ui/my-profile/tsconfig.spec.json
+++ b/libs/ui/my-profile/tsconfig.spec.json
@@ -2,7 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/password-reset/tsconfig.spec.json
+++ b/libs/ui/password-reset/tsconfig.spec.json
@@ -2,7 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/registration/tsconfig.spec.json
+++ b/libs/ui/registration/tsconfig.spec.json
@@ -2,8 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"],
-  "exclude": ["jest.config.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/routable-dialog/src/index.ts
+++ b/libs/ui/routable-dialog/src/index.ts
@@ -1,0 +1,2 @@
+export * from './routed-dialog-button.directive';
+export * from './routable-dialog.component';

--- a/libs/ui/routable-dialog/tsconfig.json
+++ b/libs/ui/routable-dialog/tsconfig.json
@@ -1,19 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022", "DOM"],
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "outDir": "../../../dist/out-tsc",
-    "rootDir": ".",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
 }

--- a/libs/ui/routable-dialog/tsconfig.lib.json
+++ b/libs/ui/routable-dialog/tsconfig.lib.json
@@ -4,6 +4,6 @@
     "outDir": "../../../dist/out-tsc",
     "types": []
   },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libs/ui/routable-dialog/tsconfig.spec.json
+++ b/libs/ui/routable-dialog/tsconfig.spec.json
@@ -2,7 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/routing/tsconfig.json
+++ b/libs/ui/routing/tsconfig.json
@@ -1,19 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022", "DOM"],
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "outDir": "../../../dist/out-tsc",
-    "rootDir": ".",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
 }

--- a/libs/ui/routing/tsconfig.lib.json
+++ b/libs/ui/routing/tsconfig.lib.json
@@ -4,6 +4,6 @@
     "outDir": "../../../dist/out-tsc",
     "types": []
   },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libs/ui/routing/tsconfig.spec.json
+++ b/libs/ui/routing/tsconfig.spec.json
@@ -2,7 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }

--- a/libs/ui/search-bar/tsconfig.json
+++ b/libs/ui/search-bar/tsconfig.json
@@ -1,19 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "lib": ["ES2022", "DOM"],
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "outDir": "../../../dist/out-tsc",
-    "rootDir": ".",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
 }

--- a/libs/ui/search-bar/tsconfig.lib.json
+++ b/libs/ui/search-bar/tsconfig.lib.json
@@ -4,6 +4,6 @@
     "outDir": "../../../dist/out-tsc",
     "types": []
   },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/libs/ui/search-bar/tsconfig.spec.json
+++ b/libs/ui/search-bar/tsconfig.spec.json
@@ -2,7 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["jasmine", "node"]
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
-  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

This PR standardizes the tsconfig configuration across all @ui libraries and fixes import paths in dialog components.

## Changes Made

### tsconfig Standardization
- Updated all @ui libraries to use simple tsconfig pattern
- Standardized tsconfig.lib.json and tsconfig.spec.json across UI libraries
- Replaced complex compiler options with simple reference structure

### Import Path Fixes
- Fixed dialog component imports to use correct path mappings
- Updated home component imports to use proper shared features
- Added missing index.ts file for routable-dialog library

### Files Modified
- 41 files changed with 209 insertions and 226 deletions
- All UI library tsconfig files updated
- Dialog component imports corrected
- Home component imports fixed

## Testing
- All imports now use proper @ui/* and @portals/shared/* path mappings
- tsconfig files follow consistent pattern across libraries
- Build errors related to import paths should be resolved