### PR TITLE
fix(ui): resolve Taiga UI icons 404 errors and missing styles

### DIFF
--- a/apps/portals/aggregator/application/src/app-config.ts
+++ b/apps/portals/aggregator/application/src/app-config.ts
@@ -2,7 +2,8 @@ import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http"
 import { ApplicationConfig } from "@angular/core";
 import { provideRouter, withEnabledBlockingInitialNavigation, withInMemoryScrolling, withRouterConfig, withComponentInputBinding, Routes } from "@angular/router";
 import { provideAnimations } from "@angular/platform-browser/animations";
-import { NG_EVENT_PLUGINS } from '@taiga-ui/event-plugins'; 
+import { NG_EVENT_PLUGINS } from '@taiga-ui/event-plugins';
+import { TUI_ASSETS_PATH, tuiAssetsPathProvider } from '@taiga-ui/core'; 
 
 export function createAppConfig(c: {
   routes: Routes,
@@ -24,6 +25,7 @@ export function createAppConfig(c: {
       provideHttpClient(withInterceptorsFromDi()),
       provideAnimations(),
       NG_EVENT_PLUGINS,
+      tuiAssetsPathProvider('assets/taiga-ui/icons'),
       //StoreDevtoolsModule.instrument()
     ],
   }

--- a/apps/portals/aggregator/application/src/components/partials/header/header.component.ts
+++ b/apps/portals/aggregator/application/src/components/partials/header/header.component.ts
@@ -45,8 +45,8 @@ export class HeaderPartialComponent {
 
   // Navigation items - these should come from a proper navigation configuration
   public readonly navigationItems = {
-    applications: { icon: 'tuiIconApps', label: 'Applications' },
-    suites: { icon: 'tuiIconPackage', label: 'Suites' },
-    articles: { icon: 'tuiIconFileText', label: 'Articles' }
+    applications: { icon: 'app-window', label: 'Applications' },
+    suites: { icon: 'package', label: 'Suites' },
+    articles: { icon: 'file-text', label: 'Articles' }
   };
 }

--- a/apps/portals/aggregator/application/src/styles.scss
+++ b/apps/portals/aggregator/application/src/styles.scss
@@ -1,6 +1,8 @@
-@use "@taiga-ui/core/styles/taiga-ui-local";
 @use 'variables';
 @use 'theme';
+
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@500;800&display=swap');
+@import "@taiga-ui/core/styles/taiga-ui-local";
 
 :host, html {
   width: 100%;

--- a/apps/portals/aggregator/entrypoints/csr/project.json
+++ b/apps/portals/aggregator/entrypoints/csr/project.json
@@ -16,9 +16,20 @@
         "polyfills": ["zone.js"],
         "tsConfig": "apps/portals/aggregator/entrypoints/csr/tsconfig.app.json",
         "assets": [
-          "apps/portals/aggregator/entrypoints/csr/src/assets"
+          "apps/portals/aggregator/entrypoints/csr/src/assets",
+          {
+            "glob": "**/*",
+            "input": "node_modules/@taiga-ui/icons/src",
+            "output": "assets/taiga-ui/icons"
+          }
         ],
-        "styles": ["apps/portals/aggregator/entrypoints/csr/src/styles.scss"],
+        "styles": [
+          "apps/portals/aggregator/application/src/styles.scss",
+          {
+            "input": "node_modules/@taiga-ui/core/styles/taiga-ui-theme.less",
+            "bundleName": "taiga-theme"
+          }
+        ],
         "scripts": []
       },
       "configurations": {

--- a/apps/portals/aggregator/entrypoints/ssg/project.json
+++ b/apps/portals/aggregator/entrypoints/ssg/project.json
@@ -17,9 +17,20 @@
         "tsConfig": "apps/portals/aggregator/src/apps/angular/tsconfig.app.json",
         "assets": [
           "apps/portals/aggregator/src/apps/angular/src/favicon.ico",
-          "apps/portals/aggregator/src/apps/angular/src/assets"
+          "apps/portals/aggregator/src/apps/angular/src/assets",
+          {
+            "glob": "**/*",
+            "input": "node_modules/@taiga-ui/icons/src",
+            "output": "assets/taiga-ui/icons"
+          }
         ],
-        "styles": ["apps/portals/aggregator/src/apps/angular/src/styles.scss"],
+        "styles": [
+          "apps/portals/aggregator/application/src/styles.scss",
+          {
+            "input": "node_modules/@taiga-ui/core/styles/taiga-ui-theme.less",
+            "bundleName": "taiga-theme"
+          }
+        ],
         "scripts": []
       },
       "configurations": {

--- a/apps/portals/aggregator/entrypoints/ssr/project.json
+++ b/apps/portals/aggregator/entrypoints/ssr/project.json
@@ -17,9 +17,20 @@
         "tsConfig": "apps/portals/aggregator/src/apps/angular/tsconfig.app.json",
         "assets": [
           "apps/portals/aggregator/src/apps/angular/src/favicon.ico",
-          "apps/portals/aggregator/src/apps/angular/src/assets"
+          "apps/portals/aggregator/src/apps/angular/src/assets",
+          {
+            "glob": "**/*",
+            "input": "node_modules/@taiga-ui/icons/src",
+            "output": "assets/taiga-ui/icons"
+          }
         ],
-        "styles": ["apps/portals/aggregator/src/apps/angular/src/styles.scss"],
+        "styles": [
+          "apps/portals/aggregator/application/src/styles.scss",
+          {
+            "input": "node_modules/@taiga-ui/core/styles/taiga-ui-theme.less",
+            "bundleName": "taiga-theme"
+          }
+        ],
         "scripts": []
       },
       "configurations": {

--- a/libs/ui/login/src/login-form.component.html
+++ b/libs/ui/login/src/login-form.component.html
@@ -2,7 +2,7 @@
   <div class="form-field">
     <tui-input
       formControlName="login"
-      tuiTextfieldIconLeft="tuiIconMailLarge">
+      tuiTextfieldIconLeft="mail">
       Email
     </tui-input>
     <div class="error-container">


### PR DESCRIPTION
## Summary

This PR resolves Taiga UI icon 404 errors and missing styles issues in the aggregator portal.

## Changes Made

### 🔧 Icon Assets Configuration
- Added Taiga UI icon assets configuration to copy icons from node_modules to build output
- Fixed icon path configuration using tuiAssetsPathProvider in app-config.ts
- Updated all entrypoints (CSR, SSG, SSR) with proper asset copying

### 🎨 Icon Name Fixes
- Updated icon names in components to match actual SVG file names:
  - `tuiIconFileText` → `file-text`
  - `tuiIconApps` → `app-window`
  - `tuiIconPackage` → `package`
  - `tuiIconMailLarge` → `mail`

### 🎭 Theme & Styles
- Added Taiga UI theme CSS as separate bundle to include all CSS variables
- Imported Google Fonts (Manrope) for proper typography
- Updated styles configuration in all entrypoints

## Files Modified
- `apps/portals/aggregator/application/src/app-config.ts`
- `apps/portals/aggregator/application/src/components/partials/header/header.component.ts`
- `apps/portals/aggregator/application/src/styles.scss`
- `apps/portals/aggregator/entrypoints/csr/project.json`
- `apps/portals/aggregator/entrypoints/ssg/project.json`
- `apps/portals/aggregator/entrypoints/ssr/project.json`
- `libs/ui/login/src/login-form.component.html`

## Testing
- ✅ All Taiga UI icons now load without 404 errors
- ✅ Proper fonts and styling applied
- ✅ Build process completes successfully
- ✅ Development server runs without errors

## Result
The application now displays with proper Taiga UI theming, fonts, and working icons throughout the interface.